### PR TITLE
Fix fluid processor getting stuck on magic extra 1mb fluid stack

### DIFF
--- a/src/main/kotlin/net/ndrei/bcoreprocessing/machines/fluidprocessor/FluidProcessorTile.kt
+++ b/src/main/kotlin/net/ndrei/bcoreprocessing/machines/fluidprocessor/FluidProcessorTile.kt
@@ -72,6 +72,15 @@ class FluidProcessorTile
 
     override fun innerUpdate() {
         val power = 6 * MjAPI.ONE_MINECRAFT_JOULE
+
+	val cf = this.currentFluid
+	val nf = this.fluidTank.fluid
+	if (cf != null && nf != null) {
+	  if (cf.amount == 1 && cf.getFluid() != nf.getFluid()) {
+	    this.currentFluid = null
+	  }
+	}
+	
         val inputFluid = this.currentFluid ?: this.fluidTank.fluid
         if ((inputFluid != null) && (inputFluid.amount > 0) && (this.battery.stored >= power) && this.itemHandler.getStackInSlot(0).isEmpty) {
             val recipe = FluidProcessorRecipeManager.findFirstRecipe(inputFluid, true)


### PR DESCRIPTION
If used with pipes from a mod faster than BC's native fluid pipes (encountered with ThermalDynamics pipes), the FluidProcessor can get stuck when the input fluid type changes.  It ends up with 1mb left of the first input fluid, and a normal amount of fluid in the input tank.

This is a quick and dirty fix, which is capable of fixing already jammed FluidProcessors in existing worlds.  A more complete solution would not call `this.currentFluid = fluidAtTick.copyWithSize(1)` but I think this is good enough.

Also, since BC disabled RF input, if there is interest, I have a patch that enables it (both for base BC, and for this mod).  I can provide a PR if desired.